### PR TITLE
Add alert for access denial on unauthorized homepage access

### DIFF
--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -4,16 +4,32 @@ import Noteitem from "./Noteitem";
 import AddNote from "./AddNote";
 import { useNavigate } from "react-router-dom";
 import imageCompression from "browser-image-compression";
+import Alert from "./Alert";
 export default function Notes(props) {
   const context = useContext(noteContext);
   const { notes, getNotes,editNote } = context;
   const navigate = useNavigate();
+  const [alert, setalert] = useState(null);
+
+  const showAlert = (message, type) => {
+    setalert({
+      msg: message,
+      type: type,
+    });
+    setTimeout(() => {
+      setalert(null);
+    }, 1500); // Alert will disappear after 1.5 seconds
+  };
   useEffect(() => {
     if(localStorage.getItem('token')){
       console.log(localStorage.getItem('token'))
       getNotes()
     } else {
-      navigate("/login")
+      showAlert("Access Denied: You must be logged in to view the homepage.", "danger");
+      // Delay navigation for 1.5 seconds (same time as alert disappearance)
+      setTimeout(() => {
+        navigate("/login");
+      }, 1500);
     }
     
   }, []);
@@ -79,6 +95,16 @@ export default function Notes(props) {
       setnote({ ...note, [e.target.name]: e.target.value });
     }
   };
+
+
+  if(alert){
+    return <div>
+    {/* Pass the alert state to your Alert component */}
+    <Alert alert={alert} />
+    
+    {/* Rest of your component */}
+  </div>
+  }
 
   return (
     <>


### PR DESCRIPTION
Added alert before navigation to login page for unauthenticated users

- Implemented user awareness alert when accessing homepage without authentication
- Delayed navigation to login page by 1.5  seconds after showing the alert
- Improved user experience by clearly informing users about the need to log in by displaying danger error there

<img width="1470" alt="Screenshot 2024-10-16 at 6 50 31 PM" src="https://github.com/user-attachments/assets/4f7ca8c8-bd43-43f0-9bd8-a157a543b0bf">
forming users about the need to log in

